### PR TITLE
prevents deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: write php-fpm-pool.conf
   template: "src=php-fpm-pool.conf.j2 dest='/etc/php/7.0/fpm/pool.d/{{ item.name }}.conf' owner=root group=root mode=0644"
-  with_items: php_fpm_pools
+  with_items: '{{ php_fpm_pools }}'
   notify:
     - restart php-fpm
 


### PR DESCRIPTION
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{php_fpm_pools}}'). This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
